### PR TITLE
Update website url in docusaurus config

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: 'CodeshiftCommunity',
   tagline: 'Codemods for everyone ✨',
-  url: 'https://your-docusaurus-test-site.com',
+  url: 'https://www.codeshiftcommunity.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
Currently the website url in docusaurus config is the default test url. Updating it to properly generate open graph meta information for various pages in the website.