### PR TITLE
CLI sub-commands for creating and validating (not publishing yet) external codemods

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "types:check": "tsc --noEmit --skipLibCheck",
     "monorepo:check": "manypkg check",
     "monorepo:fix": "manypkg fix && preconstruct fix",
-    "init:codemods": "ts-node packages/initializer/src/index.ts",
+    "init:codemods": "ts-node scripts/initialize.ts",
     "start:codemods": "node packages/cli/bin/codeshift-cli.js",
     "validate:codemods": "ts-node packages/validator/src/index.ts ./community",
     "release:codemods": "ts-node packages/publisher/src/index.ts ./community ./.tmp",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "monorepo:fix": "manypkg fix && preconstruct fix",
     "init:codemods": "ts-node scripts/initialize.ts",
     "start:codemods": "node packages/cli/bin/codeshift-cli.js",
-    "validate:codemods": "ts-node packages/validator/src/index.ts ./community",
+    "validate:codemods": "ts-node scripts/validate.ts ./community",
     "release:codemods": "ts-node packages/publisher/src/index.ts ./community ./.tmp",
     "prerelease": "yarn validate && yarn test",
     "release": "yarn changeset publish"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,8 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
+    "@codeshift/initializer": "0.1.0",
+    "@codeshift/validator": "0.1.0",
     "chalk": "^4.1.0",
     "commander": "^7.2.0",
     "fs-extra": "^9.1.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import main from './main';
 import list from './list';
+import init from './init';
 import {
   ValidationError,
   NoTransformsExistError,
@@ -64,6 +65,21 @@ program
   .command('list <package-names...>')
   .description('list available codemods for provided packages')
   .action(packageNames => list(packageNames));
+
+program
+  .command('init [path]')
+  .description('create a new codemod package')
+  // FIXME: Commander seems to have issues parsing the paths and arguments
+  .option('--package-name <name>', 'Name of the package')
+  .option('--version <version>', 'Target version')
+  .action((path, options) => init(options.packageName, options.version, path))
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ npx @codeshift/cli init --package-name foobar --version 10.0.0 ~/Desktop
+  `,
+  );
 
 program.exitOverride();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import main from './main';
 import list from './list';
 import init from './init';
+import validate from './validate';
 import {
   ValidationError,
   NoTransformsExistError,
@@ -78,6 +79,19 @@ program
     `
 Examples:
   $ npx @codeshift/cli init --package-name foobar --version 10.0.0 ~/Desktop
+  `,
+  );
+
+program
+  .command('validate [path]')
+  .description('validates if a codemod package is publishable')
+  .action(path => validate(path))
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ npx @codeshift/cli validate
+  $ npx @codeshift/cli validate ./codemods/my-codemods
   `,
   );
 

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,0 +1,13 @@
+import { initDirectory } from '@codeshift/initializer';
+
+export default async function init(
+  packageName: string,
+  version: string,
+  targetPath: string = '.',
+) {
+  initDirectory(packageName, version, targetPath);
+
+  console.log(
+    `🚚 New codemod package created at: ${targetPath}/${packageName}`,
+  );
+}

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,0 +1,13 @@
+import { isValidConfig, isValidPackageJson } from '@codeshift/validator';
+
+export default async function validate(targetPath: string = '.') {
+  try {
+    await isValidConfig(targetPath);
+    await isValidPackageJson(targetPath);
+  } catch (error) {
+    console.warn(error);
+    process.exit(1);
+  }
+
+  console.log('Valid ✅');
+}

--- a/packages/initializer/package.json
+++ b/packages/initializer/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@codeshift/initializer",
-  "private": true,
   "version": "0.1.0",
   "main": "dist/codeshift-initializer.cjs.js",
   "types": "dist/codeshift-initializer.cjs.d.ts",

--- a/packages/initializer/src/index.ts
+++ b/packages/initializer/src/index.ts
@@ -16,6 +16,7 @@ export function initDirectory(
   const basePath = `${targetPath}/${packageName.replace('/', '__')}`;
   const codemodPath = `${basePath}/${version}`;
   const configPath = `${basePath}/codeshift.config.js`;
+  const packagePath = `${basePath}/package.json`;
   const motionsPath = `${codemodPath}/motions`;
 
   fs.mkdirSync(codemodPath, { recursive: true });
@@ -36,6 +37,22 @@ export function initDirectory(
     .replace('<% version %>', version);
 
   fs.writeFileSync(`${codemodPath}/transform.spec.ts`, testFile);
+
+  fs.writeFileSync(
+    packagePath,
+    `{
+  "name": "${packageName}",
+  "version": "0.0.1",
+  "license": "MIT",
+  "main": "dist/${packageName}.cjs.js",
+  "dependencies": {
+    "@codeshift/utils": "^0.1.2"
+  },
+  "devDependencies": {
+    "jscodeshift": "^0.12.0"
+  }
+}`,
+  );
 
   if (!fs.existsSync(configPath)) {
     fs.writeFileSync(

--- a/packages/initializer/src/index.ts
+++ b/packages/initializer/src/index.ts
@@ -2,21 +2,20 @@ import fs from 'fs-extra';
 import semver from 'semver';
 import * as recast from 'recast';
 
-function main(packageName: string, version: string) {
-  if (!packageName) throw new Error('Package name was not provided');
-  if (!version) throw new Error('Version was not provided');
-
+export function initDirectory(
+  packageName: string,
+  version: string,
+  targetPath: string = './',
+) {
   if (!semver.valid(version)) {
     throw new Error(
       `Provided version ${version} is not a valid semver version`,
     );
   }
 
-  const communityDirectoryPath = `${__dirname}/../../../community`;
-  const safePackageName = packageName.replace('/', '__');
-  const codemodBasePath = `${communityDirectoryPath}/${safePackageName}`;
-  const codemodPath = `${codemodBasePath}/${version}`;
-  const configPath = `${codemodBasePath}/codeshift.config.js`;
+  const basePath = `${targetPath}/${packageName.replace('/', '__')}`;
+  const codemodPath = `${basePath}/${version}`;
+  const configPath = `${basePath}/codeshift.config.js`;
   const motionsPath = `${codemodPath}/motions`;
 
   fs.mkdirSync(codemodPath, { recursive: true });
@@ -88,10 +87,4 @@ function main(packageName: string, version: string) {
       recast.prettyPrint(ast, { quote: 'single', trailingComma: true }).code,
     );
   }
-
-  console.log(
-    `🚚 New codemod package created at: community/${safePackageName}/${version}`,
-  );
 }
-
-main(process.argv[2], process.argv[3]);

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@codeshift/validator",
-  "private": true,
   "version": "0.1.0",
   "main": "dist/codeshift-validator.cjs.js",
   "types": "dist/codeshift-validator.cjs.d.ts",
@@ -11,6 +10,7 @@
   },
   "dependencies": {
     "fs-extra": "^9.1.0",
+    "recast": "^0.20.4",
     "semver": "^7.3.5",
     "ts-node": "^9.1.1"
   }

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,55 +1,63 @@
-import fs, { lstatSync, existsSync } from 'fs-extra';
+import fs from 'fs-extra';
 import semver from 'semver';
+import * as recast from 'recast';
 
 const packageNameRegex = /^(@[a-z0-9-~][a-z0-9-._~]*__)?[a-z0-9-~][a-z0-9-._~]*$/;
 
-async function main(path: string) {
-  const directories = await fs.readdir(path);
-
-  directories.forEach(async dir => {
-    if (!dir.match(packageNameRegex)) {
-      throw new Error(
-        `Invalid package name: ${dir}.
-        If this is a scoped package, please make sure rename the folder to use the "__" characters to denote submodule.
-        For example: @atlaskit/avatar => @atlaskit__avatar`,
-      );
-    }
-
-    const subDirectories = await fs.readdir(`${path}/${dir}`);
-    let hasConfigFile = false;
-
-    subDirectories.forEach(subDir => {
-      if (subDir === 'codeshift.config.js') {
-        hasConfigFile = true;
-      }
-
-      if (
-        lstatSync(`${path}/${dir}/${subDir}`).isDirectory() &&
-        !semver.valid(subDir)
-      ) {
-        throw new Error(
-          `Codemod folder name "${subDir}" has an invalid version name. Please make sure the file name is valid semver. For example "18.0.0"`,
-        );
-      }
-
-      if (
-        lstatSync(`${path}/${dir}/${subDir}`).isDirectory() &&
-        !existsSync(`${path}/${dir}/${subDir}/transform.ts`) &&
-        !existsSync(`${path}/${dir}/${subDir}/transform.js`)
-      ) {
-        throw new Error(
-          `Unable to find transform entry-point for directory "${path}/${dir}/${subDir}". Please ensure you have a valid transform.(ts|js) file containing the entry-point for your codemod`,
-        );
-      }
-    });
-
-    if (!hasConfigFile) {
-      throw new Error(
-        `No config file found at: ${path}/${dir}.
-        Please create a config file named "codeshift.config.js"`,
-      );
-    }
-  });
+export function isValidPackageName(dir: string) {
+  return dir.match(packageNameRegex);
 }
 
-main(process.argv[2]);
+export async function isValidConfig(path: string) {
+  const configPath = path + `/codeshift.config.js`;
+  const source = await fs.readFile(configPath, 'utf8');
+  const ast = recast.parse(source);
+
+  let hasTransforms = false;
+  let invalidSemverIds = [];
+  let transformCount = 0;
+
+  recast.visit(ast, {
+    visitProperty(path) {
+      // @ts-ignore
+      if (path.node.key.name === 'transforms') {
+        hasTransforms = true;
+        // @ts-ignore
+        const properties = path.node.value.properties;
+        transformCount = properties.length;
+        // @ts-ignore
+        properties.forEach(property => {
+          if (!semver.valid(property.key.value)) {
+            invalidSemverIds.push(property.key.value);
+          }
+        });
+      }
+
+      return false;
+    },
+  });
+
+  if (!hasTransforms || !transformCount) {
+    throw new Error(
+      'At least one transform should be specified for config at "${configPath}"',
+    );
+  }
+
+  if (invalidSemverIds.length) {
+    throw new Error(`Invalid transform ids found for config at "${configPath}".
+      Please make sure all transforms are identified by a valid semver version. ie 10.0.0`);
+  }
+}
+
+export async function isValidPackageJson(path: string) {
+  const packageJsonRaw = await fs.readFile(path + '/package.json', 'utf8');
+  const packageJson = JSON.parse(packageJsonRaw);
+
+  if (!packageJson.name) {
+    throw new Error('No package name provided in package.json');
+  }
+
+  if (!packageJson.main) {
+    throw new Error('No main entrypoint provided in package.json');
+  }
+}

--- a/scripts/initialize.ts
+++ b/scripts/initialize.ts
@@ -1,0 +1,16 @@
+import { initDirectory } from '@codeshift/initializer';
+
+export function main(packageName: string, version: string) {
+  const path = `${__dirname}/../community`;
+
+  if (!packageName) throw new Error('Package name was not provided');
+  if (!version) throw new Error('Version was not provided');
+
+  initDirectory(packageName, version, path);
+
+  console.log(
+    `🚚 New codemod package created at: community/${packageName}/${version}`,
+  );
+}
+
+main(process.argv[2], process.argv[3]);

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,0 +1,43 @@
+import fs, { lstatSync, existsSync } from 'fs-extra';
+import semver from 'semver';
+import { isValidPackageName, isValidConfig } from '@codeshift/validator';
+
+async function main(path: string) {
+  const directories = await fs.readdir(path);
+
+  directories.forEach(async dir => {
+    if (!isValidPackageName(dir)) {
+      throw new Error(
+        `Invalid package name: ${dir}.
+        If this is a scoped package, please make sure rename the folder to use the "__" characters to denote submodule.
+        For example: @foo/bar => @foo__bar`,
+      );
+    }
+
+    await isValidConfig(`${path}/${dir}`);
+
+    const subDirectories = await fs.readdir(`${path}/${dir}`);
+    subDirectories.forEach(async subDir => {
+      if (
+        lstatSync(`${path}/${dir}/${subDir}`).isDirectory() &&
+        !semver.valid(subDir)
+      ) {
+        throw new Error(
+          `Codemod folder name "${subDir}" has an invalid version name. Please make sure the file name is valid semver. For example "18.0.0"`,
+        );
+      }
+
+      if (
+        lstatSync(`${path}/${dir}/${subDir}`).isDirectory() &&
+        !existsSync(`${path}/${dir}/${subDir}/transform.ts`) &&
+        !existsSync(`${path}/${dir}/${subDir}/transform.js`)
+      ) {
+        throw new Error(
+          `Unable to find transform entry-point for directory "${path}/${dir}/${subDir}". Please ensure you have a valid transform.(ts|js) file containing the entry-point for your codemod`,
+        );
+      }
+    });
+  });
+}
+
+main(process.argv[2]);

--- a/website/docs/api/codeshift-cli.mdx
+++ b/website/docs/api/codeshift-cli.mdx
@@ -128,3 +128,17 @@ Create a new codemod package called foobar with a transform for version 10
 on the Desktop
 
 - `@codeshift/cli init --packageName="foobar" --version"10.0.0" ~/Desktop`
+
+### validate
+
+Validates a codemod package at the desired path.
+
+**example:**
+
+Validate a codemod package called "my-codemods".
+
+- `$ npx @codeshift/cli validate ./codemods/my-codemods`
+
+Validate a codemod package from the current working directory
+
+- `$ npx @codeshift/cli validate`

--- a/website/docs/api/codeshift-cli.mdx
+++ b/website/docs/api/codeshift-cli.mdx
@@ -117,3 +117,14 @@ Print a list of available codemods for a single package
 Print a list of available codemods for multiple packages
 
 - `@codeshift/cli list mylib, @material-ui/button`
+
+### init
+
+Generates a new codemod at your desired path
+
+**example:**
+
+Create a new codemod package called foobar with a transform for version 10
+on the Desktop
+
+- `@codeshift/cli init --packageName="foobar" --version"10.0.0" ~/Desktop`


### PR DESCRIPTION
Adds sub-commands to the cli that `initialize`, `validate` codemods external to the community repo. 

These codemods will likely be for cases where: 
- They're highly specific to a repo or organisation
- Need to be private or closed-source
- Don't want overhead or approval to contribute to this repo

**Related issues:** #8, #6
**Closes:** #28, #27

This PR includes:
- Refactors internal helper scripts
- Adds `initialize`, `validate` commands to CLI

TODO:
- [x] Init to generate `package.json`
