### PR TITLE
Refactor repo scripts

### DIFF
--- a/.changeset/three-cougars-yawn.md
+++ b/.changeset/three-cougars-yawn.md
@@ -1,0 +1,8 @@
+---
+'@codeshift/cli': patch
+'@codeshift/initializer': patch
+'@codeshift/publisher': patch
+'@codeshift/validator': patch
+---
+
+Update package configuration and refactors repo scripts

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "validate:codemods": "ts-node scripts/validate.ts ./community",
     "release:codemods": "ts-node scripts/publish.ts ./community ./.tmp",
     "release-all:codemods": "ts-node scripts/publish-all.ts ./community ./.tmp",
+    "release-all-dry:codemods": "ts-node scripts/publish-all-dry.ts ./community ./.tmp",
     "prerelease": "yarn validate && yarn test",
     "release": "yarn changeset publish"
   },

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "types:check": "tsc --noEmit --skipLibCheck",
     "monorepo:check": "manypkg check",
     "monorepo:fix": "manypkg fix && preconstruct fix",
-    "init:codemods": "ts-node scripts/initialize.ts",
     "start:codemods": "node packages/cli/bin/codeshift-cli.js",
+    "init:codemods": "ts-node scripts/initialize.ts",
     "validate:codemods": "ts-node scripts/validate.ts ./community",
-    "release:codemods": "ts-node packages/publisher/src/index.ts ./community ./.tmp",
+    "release:codemods": "ts-node scripts/publish.ts ./community ./.tmp",
+    "release-all:codemods": "ts-node scripts/publish-all.ts ./community ./.tmp",
     "prerelease": "yarn validate && yarn test",
     "release": "yarn changeset publish"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,8 @@
     "codemod-cli": "./bin/codeshift-cli.js"
   },
   "scripts": {
-    "start": "ts-node src/index.ts"
+    "start": "./bin/codeshift-cli.js",
+    "start:dev": "ts-node src/index.ts"
   },
   "dependencies": {
     "@codeshift/initializer": "0.1.0",

--- a/packages/cli/src/main.spec.ts
+++ b/packages/cli/src/main.spec.ts
@@ -7,6 +7,7 @@ jest.mock('live-plugin-manager', () => ({
     install: () => Promise.resolve(undefined),
     getInfo: (name: string) =>
       Promise.resolve({ location: `node_modules/${name}` }),
+    uninstallAll: () => Promise.resolve(),
   }),
 }));
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -99,8 +99,5 @@ export default async function main(paths: string[], flags: Flags) {
     });
   }
 
-  /**
-   * TODO: uncomment the below when jscodeshift can be used as an async function
-   */
-  // await packageManager.uninstallAll();
+  await packageManager.uninstallAll();
 }

--- a/packages/initializer/package.json
+++ b/packages/initializer/package.json
@@ -5,9 +5,6 @@
   "types": "dist/codeshift-initializer.cjs.d.ts",
   "license": "MIT",
   "repository": "https://github.com/CodeshiftCommunity/CodeshiftCommunity/tree/master/packages/initializer",
-  "scripts": {
-    "start": "ts-node src/index.ts"
-  },
   "dependencies": {
     "fs-extra": "^9.1.0",
     "recast": "^0.20.4",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,15 +1,12 @@
 {
   "name": "@codeshift/publisher",
-  "private": true,
   "version": "0.1.0",
   "main": "dist/codeshift-publisher.cjs.js",
   "types": "dist/codeshift-publisher.cjs.d.ts",
   "license": "MIT",
   "repository": "https://github.com/CodeshiftCommunity/CodeshiftCommunity/tree/master/packages/publisher",
-  "scripts": {
-    "start": "ts-node src/index.ts"
-  },
   "dependencies": {
+    "@preconstruct/cli": "^2.0.0",
     "fs-extra": "^9.1.0",
     "npm-registry-client": "^8.6.0",
     "semver": "^7.3.5",

--- a/packages/publisher/src/changed.ts
+++ b/packages/publisher/src/changed.ts
@@ -1,12 +1,16 @@
 import simpleGit from 'simple-git/promise';
 import fs from 'fs-extra';
 
-export default async function getChangedPackages() {
-  const git = simpleGit();
+export function getAllPackages(path: string) {
+  return fs
+    .readdirSync(path, { withFileTypes: true })
+    .filter(dir => dir.isDirectory())
+    .map(dir => dir.name);
+}
 
-  const eventMeta = JSON.parse(
-    fs.readFileSync(process.env.GITHUB_EVENT_PATH!, 'utf8'),
-  );
+export async function getChangedPackages(sinceRef: string) {
+  const git = simpleGit();
+  const eventMeta = JSON.parse(fs.readFileSync(sinceRef!, 'utf8'));
 
   try {
     await git.revparse(['--verify', eventMeta.before]);

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -1,34 +1,4 @@
-import generatePackages, { cleanTargetDir } from './generate';
-import getChangedPackages from './changed';
-import buildPackages from './build';
-import publishPackages from './publish';
-
-async function main(sourcePath: string, targetPath: string) {
-  cleanTargetDir(targetPath);
-
-  console.log('Calculating changed packages');
-  const changedPackages = await getChangedPackages();
-
-  if (changedPackages.length === 0) {
-    console.log('No packages changed, exiting...');
-    process.exit(0);
-  }
-
-  console.log('Changed packages', changedPackages);
-
-  console.log('Generating temporary directory');
-  await generatePackages(sourcePath, targetPath, changedPackages);
-
-  console.log('Building changed packages');
-  await buildPackages();
-
-  console.log('Publishing changed packages');
-  await publishPackages(targetPath, process.env.NPM_TOKEN!);
-
-  console.log('Cleaning up temporary directory');
-  cleanTargetDir(targetPath);
-}
-
-main(process.argv[2], process.argv[3]).catch(error => {
-  console.error('Publishing error:', error.message);
-});
+export { default as generatePackages, cleanTargetDir } from './generate';
+export { getChangedPackages, getAllPackages } from './changed';
+export { default as buildPackages } from './build';
+export { default as publishPackages } from './publish';

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -5,9 +5,6 @@
   "types": "dist/codeshift-validator.cjs.d.ts",
   "license": "MIT",
   "repository": "https://github.com/CodeshiftCommunity/CodeshiftCommunity/tree/master/packages/validator",
-  "scripts": {
-    "start": "ts-node src/index.ts"
-  },
   "dependencies": {
     "fs-extra": "^9.1.0",
     "recast": "^0.20.4",

--- a/scripts/publish-all-dry.ts
+++ b/scripts/publish-all-dry.ts
@@ -1,0 +1,23 @@
+import {
+  getAllPackages,
+  buildPackages,
+  generatePackages,
+  cleanTargetDir,
+} from '@codeshift/publisher';
+
+async function main(sourcePath: string, targetPath: string) {
+  cleanTargetDir(targetPath);
+
+  const packages = getAllPackages(sourcePath);
+  console.log(packages);
+
+  console.log('Generating temporary directory');
+  await generatePackages(sourcePath, targetPath, packages);
+
+  console.log('Building all packages');
+  await buildPackages();
+}
+
+main(process.argv[2], process.argv[3]).catch(error => {
+  console.error('Publishing error:', error.message);
+});

--- a/scripts/publish-all.ts
+++ b/scripts/publish-all.ts
@@ -1,0 +1,30 @@
+import {
+  getAllPackages,
+  buildPackages,
+  generatePackages,
+  cleanTargetDir,
+  publishPackages,
+} from '@codeshift/publisher';
+
+async function main(sourcePath: string, targetPath: string) {
+  cleanTargetDir(targetPath);
+
+  const packages = getAllPackages(sourcePath);
+  console.log(packages);
+
+  console.log('Generating temporary directory');
+  await generatePackages(sourcePath, targetPath, packages);
+
+  console.log('Building all packages');
+  await buildPackages();
+
+  console.log('Publishing all packages');
+  await publishPackages(targetPath, process.env.NPM_TOKEN!);
+
+  console.log('Cleaning up temporary directory');
+  cleanTargetDir(targetPath);
+}
+
+main(process.argv[2], process.argv[3]).catch(error => {
+  console.error('Publishing error:', error.message);
+});

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,39 @@
+import {
+  getChangedPackages,
+  buildPackages,
+  generatePackages,
+  cleanTargetDir,
+  publishPackages,
+} from '@codeshift/publisher';
+
+async function main(sourcePath: string, targetPath: string) {
+  cleanTargetDir(targetPath);
+
+  console.log('Calculating changed packages');
+  const changedPackages = await getChangedPackages(
+    process.env.GITHUB_EVENT_PATH!,
+  );
+
+  if (changedPackages.length === 0) {
+    console.log('No packages changed, exiting...');
+    process.exit(0);
+  }
+
+  console.log('Changed packages', changedPackages);
+
+  console.log('Generating temporary directory');
+  await generatePackages(sourcePath, targetPath, changedPackages);
+
+  console.log('Building changed packages');
+  await buildPackages();
+
+  console.log('Publishing changed packages');
+  await publishPackages(targetPath, process.env.NPM_TOKEN!);
+
+  console.log('Cleaning up temporary directory');
+  cleanTargetDir(targetPath);
+}
+
+main(process.argv[2], process.argv[3]).catch(error => {
+  console.error('Publishing error:', error.message);
+});


### PR DESCRIPTION
- Creates new publish repo scripts (`publish`, `publish-all`, and `publish-all-dry`) derived from `@codeshift/publisher` 
- `@codeshift/publisher` is planned to be adapted into a cli sub-command / utility library for the repo scripts
- Script clean-up etc