### PR TITLE
Remote config fetching

### DIFF
--- a/.changeset/grumpy-swans-think.md
+++ b/.changeset/grumpy-swans-think.md
@@ -1,0 +1,5 @@
+---
+'@codeshift/validator': minor
+---
+
+Fundamentally simplifies and improves on how validation works.

--- a/.changeset/silly-icons-whisper.md
+++ b/.changeset/silly-icons-whisper.md
@@ -1,0 +1,5 @@
+---
+'@codeshift/types': patch
+---
+
+Initial release

--- a/.changeset/slimy-foxes-train.md
+++ b/.changeset/slimy-foxes-train.md
@@ -1,0 +1,5 @@
+---
+'@codeshift/cli': minor
+---
+
+Codemods can now be sourced from standalone npm packages such as react as long as they provide a codeshift.config.js. This allows for greater flexibility for where codemods may be distributed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "fs-extra": "^9.1.0",
     "jscodeshift": "^0.12.0",
     "live-plugin-manager": "^0.15.1",
+    "lodash": "^4.17.21",
     "semver": "^7.3.5",
     "ts-node": "^9.1.1"
   }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -11,9 +11,10 @@ import { CodeshiftConfig } from '@codeshift/types';
 import { Flags } from './types';
 import { InvalidUserInputError } from './errors';
 
-const packageManager = new PluginManager();
-
-async function fetchCommunityPackageConfig(packageName: string) {
+async function fetchCommunityPackageConfig(
+  packageName: string,
+  packageManager: PluginManager,
+) {
   const pkgName = packageName.replace('@', '').replace('/', '__');
   const commPackageName = `@codeshift/mod-${pkgName}`;
 
@@ -28,7 +29,10 @@ async function fetchCommunityPackageConfig(packageName: string) {
   return config;
 }
 
-async function fetchRemotePackageConfig(packageName: string) {
+async function fetchRemotePackageConfig(
+  packageName: string,
+  packageManager: PluginManager,
+) {
   await packageManager.install(packageName);
   const pkg = packageManager.require(packageName);
 
@@ -74,6 +78,7 @@ async function fetchRemotePackageConfig(packageName: string) {
 }
 
 export default async function main(paths: string[], flags: Flags) {
+  const packageManager = new PluginManager();
   let transforms: string[] = [];
 
   if (!flags.transform && !flags.packages) {
@@ -104,11 +109,14 @@ export default async function main(paths: string[], flags: Flags) {
       let remoteConfig;
 
       try {
-        communityConfig = await fetchCommunityPackageConfig(pkgName);
+        communityConfig = await fetchCommunityPackageConfig(
+          pkgName,
+          packageManager,
+        );
       } catch (error) {}
 
       try {
-        remoteConfig = await fetchRemotePackageConfig(pkgName);
+        remoteConfig = await fetchRemotePackageConfig(pkgName, packageManager);
       } catch (error) {}
 
       if (!communityConfig && !remoteConfig) {

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,8 +1,8 @@
-import { isValidConfig, isValidPackageJson } from '@codeshift/validator';
+import { isValidConfigAtPath, isValidPackageJson } from '@codeshift/validator';
 
 export default async function validate(targetPath: string = '.') {
   try {
-    await isValidConfig(targetPath);
+    await isValidConfigAtPath(targetPath);
     await isValidPackageJson(targetPath);
   } catch (error) {
     console.warn(error);

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,1 @@
+# @codeshift/types

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeshift/types",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "dist/codeshift-types.cjs.js",
   "module": "dist/codeshift-types.esm.js",
   "types": "dist/codeshift-types.cjs.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@codeshift/types",
+  "version": "0.0.0",
+  "main": "dist/codeshift-types.cjs.js",
+  "module": "dist/codeshift-types.esm.js",
+  "types": "dist/codeshift-types.cjs.d.ts",
+  "license": "MIT",
+  "repository": "https://github.com/CodeshiftCommunity/CodeshiftCommunity/tree/master/packages/types"
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,7 @@
+export interface CodeshiftConfig {
+  target?: string[];
+  maintainers?: string[];
+  description?: string;
+  transforms?: Record<string, string>;
+  presets?: Record<string, string>;
+}

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/CodeshiftCommunity/CodeshiftCommunity/tree/master/packages/validator",
   "dependencies": {
+    "@codeshift/types": "^0.0.1",
     "fs-extra": "^9.1.0",
     "recast": "^0.20.4",
     "semver": "^7.3.5",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -8,8 +8,12 @@
   "dependencies": {
     "@codeshift/types": "^0.0.1",
     "fs-extra": "^9.1.0",
+    "lodash": "^4.17.21",
     "recast": "^0.20.4",
     "semver": "^7.3.5",
     "ts-node": "^9.1.1"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.176"
   }
 }

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -14,25 +14,15 @@ function getConfigFromPath(filePath: string): CodeshiftConfig {
 function hasValidTransforms(transforms?: Record<string, string>) {
   if (!transforms || !Object.keys(transforms).length) return false;
 
-  let isValid = true;
-
-  Object.entries(transforms).forEach(([key]) => {
-    if (!semver.valid(key)) isValid = false;
-  });
-
-  return isValid;
+  return Object.entries(transforms).every(([key]) => semver.valid(key));
 }
 
 function hasValidPresets(presets?: Record<string, string>) {
   if (!presets || !Object.keys(presets).length) return false;
 
-  let isValid = true;
-
-  Object.entries(presets).forEach(([key]) => {
-    if (!key.match(/^[0-9a-zA-Z\-]+$/)) isValid = false;
-  });
-
-  return isValid;
+  return Object.entries(presets).every(([key]) =>
+    key.match(/^[0-9a-zA-Z\-]+$/),
+  );
 }
 
 export function isValidPackageName(dir: string) {

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -17,7 +17,7 @@ function hasValidTransforms(transforms?: Record<string, string>) {
   return Object.entries(transforms).every(([key]) => semver.valid(key));
 }
 
-function hasValidPresets(presets?: Record<string, string>) {
+function hasValidPresets(presets?: Record<string, string>): boolean {
   if (!presets || !Object.keys(presets).length) return false;
 
   return Object.entries(presets).every(([key]) =>
@@ -25,8 +25,8 @@ function hasValidPresets(presets?: Record<string, string>) {
   );
 }
 
-export function isValidPackageName(dir: string) {
-  return dir.match(/^(@[a-z0-9-~][a-z0-9-._~]*__)?[a-z0-9-~][a-z0-9-._~]*$/);
+export function isValidPackageName(dir: string): boolean {
+  return !!dir.match(/^(@[a-z0-9-~][a-z0-9-._~]*__)?[a-z0-9-~][a-z0-9-._~]*$/);
 }
 
 export function isValidConfig(config: CodeshiftConfig) {
@@ -69,4 +69,6 @@ export async function isValidPackageJson(path: string) {
   if (!packageJson.main) {
     throw new Error('No main entrypoint provided in package.json');
   }
+
+  return true;
 }

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -29,13 +29,13 @@ export function isValidPackageName(dir: string) {
   return dir.match(/^(@[a-z0-9-~][a-z0-9-._~]*__)?[a-z0-9-~][a-z0-9-._~]*$/);
 }
 
-export async function isValidConfig(config: CodeshiftConfig) {
+export function isValidConfig(config: CodeshiftConfig) {
   return (
     hasValidTransforms(config.transforms) || hasValidPresets(config.presets)
   );
 }
 
-export async function isValidConfigAtPath(filePath: string) {
+export function isValidConfigAtPath(filePath: string) {
   const config = getConfigFromPath(filePath);
 
   if (

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,5 +1,5 @@
 import fs, { lstatSync, existsSync } from 'fs-extra';
-import { isValidPackageName, isValidConfig } from '@codeshift/validator';
+import { isValidPackageName, isValidConfigAtPath } from '@codeshift/validator';
 
 async function main(path: string) {
   const directories = await fs.readdir(path);
@@ -13,7 +13,7 @@ async function main(path: string) {
       );
     }
 
-    await isValidConfig(`${path}/${dir}`);
+    await isValidConfigAtPath(`${path}/${dir}`);
 
     const subDirectories = await fs.readdir(`${path}/${dir}`);
     subDirectories.forEach(async subDir => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,6 +1722,11 @@
   resolved "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.2.tgz#3f77e84171a2b7e3198bd5717c7547a54393baf8"
   integrity sha512-jD5VbvhfMhaYN4M3qPJuhMVUg3Dfc4tvPvLEAXn6GXbs/ajDFtCQahX37GIE65ipTI3I+hEvNaXS3MYAn9Ce3Q==
 
+"@types/lodash@^4.14.176":
+  version "4.14.176"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
+  integrity sha1-ZBFQ/BzaNvv6Mp3mA7uxddfuIMA=
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -5009,10 +5014,10 @@ lodash.unescape@4.0.1:
   resolved "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
- Adds the ability to fetch modules from NPM & the community folder
- Adds the ability to provide a `codeshift.config.js` in standard modules. For example `react` could provide a config and publish it with their source. 
- Refactors the validator package

Closes: #48 