### PR TITLE
fix standalone transform runs - resolve path of transform

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import semver from 'semver';
 import chalk from 'chalk';
 import { PluginManager } from 'live-plugin-manager';
@@ -126,9 +127,10 @@ export default async function main(paths: string[], flags: Flags) {
   );
 
   for (const transform of transforms) {
-    console.log(chalk.green('Running transform:'), transform);
+    const resolvedTransformPath = path.resolve(transform);
+    console.log(chalk.green('Running transform:'), resolvedTransformPath);
 
-    await jscodeshift.run(transform, paths, {
+    await jscodeshift.run(resolvedTransformPath, paths, {
       verbose: 0,
       dry: flags.dry,
       print: true,


### PR DESCRIPTION
in the issue you linked [1] from jscodeshift, i think you forgot the `path.resolve` for non-http(s) imports (not even sure how they'd work tbh).

i tried running a local transform and it didn't work, but with this fix it did regardless of where i called the `packages/cli/bin/codeshift-cli.js` from. i think you might've been using the packages and not the --transforms flag so i understand why you could've missed it 😅

tbh there are more improvements to make w/ the local transforms (see [2] & I'll create more later) but this is the first step :D

[1] https://github.com/facebook/jscodeshift/issues/398
[2] https://github.com/CodeshiftCommunity/CodeshiftCommunity/issues/48#issuecomment-955049880