### PR TITLE
fix initializer: configPath should never be inside /src and should be .js

### DIFF
--- a/packages/initializer/src/index.ts
+++ b/packages/initializer/src/index.ts
@@ -113,7 +113,7 @@ export function initDirectory(
   const transformPath = `${basePath}${!isReduced ? '/src/' : ''}/${transform}`;
   const configPath = `${basePath}${
     !isReduced ? '/src' : ''
-  }/codeshift.config.ts`;
+  }/codeshift.config.js`;
 
   if (fs.existsSync(transformPath)) {
     throw new Error(`Codemod for ${type} "${transform}" already exists`);


### PR DESCRIPTION
im working on another improvement and having the config in .ts not .js makes it harder to work with before we run ts-node and get the built output, and this will be the same for consumers so I believe this is the better way for everyone.

wdyt?
& did i miss any spots for `codeshift.config[tj]s`?