### PR TITLE
docs: when not to code mod: Baz -> Bar typo

### DIFF
--- a/website/docs/guides/when-not-to-codemod.mdx
+++ b/website/docs/guides/when-not-to-codemod.mdx
@@ -153,7 +153,7 @@ You now have to expand your transform to not only look for `Identifiers` with th
 What if we could side-step that entire part of the transform and simply alias the import instead?
 
 ```diff
-+import { Foo, Bar as Baz } from 'my-module';
++import { Foo, Baz as Bar } from 'my-module';
 -import { Foo, Bar } from 'my-module';
 
 console.log(Bar);


### PR DESCRIPTION
Fixed an error in code example, `Baz` should be renamed to `Bar`. Since API has a new name (according to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)).

☝️*Thanks for such a nice resource! I want to suggest one more player in codemode game: 🐊[**Putout**](https://github.com/coderaiser/putout), it has much simpler and more declarative API then JSCodeshift.*