### PR TITLE
feat: allow file input in `applyTransform` test util

### DIFF
--- a/.changeset/strange-yaks-rescue.md
+++ b/.changeset/strange-yaks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@codeshift/test-utils': minor
+---
+
+Allows to use an FileInfo in the applyTransform test util

--- a/packages/test-utils/src/apply-transform.ts
+++ b/packages/test-utils/src/apply-transform.ts
@@ -1,4 +1,4 @@
-import jscodeshift from 'jscodeshift';
+import jscodeshift, { FileInfo } from 'jscodeshift';
 
 type Parser = 'babel' | 'babylon' | 'flow' | 'ts' | 'tsx';
 
@@ -8,15 +8,18 @@ interface Options {
 
 export default async function applyTransform(
   transform: any,
-  input: string,
+  input: string | FileInfo,
   options: Options = {
     parser: 'babel',
   },
 ) {
   // Handle ES6 modules using default export for the transform
   const transformer = transform.default ? transform.default : transform;
+
+  const file = typeof input === 'string' ? { source: input } : input;
+
   const output = await transformer(
-    { source: input },
+    file,
     {
       jscodeshift: jscodeshift.withParser(options.parser as string),
       // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
Fixes: https://github.com/CodeshiftCommunity/CodeshiftCommunity/issues/150

This allows to define the `path` for the file in the transformer, for example

```ts
    const result = await applyTransform(
      transformer,
      {
        path: "src/components/Example.tsx",
        source: `
        import React, { useState } from "react";
      
        export default function Example() {
        const [state] = useState("Hello World");
      
        return <div>{state}</div>;
      }`,
      },
      { parser: "tsx" }
    );
```