### PR TITLE
feat: allow sequence in monorepo development

### DIFF
--- a/.changeset/little-spiders-develop.md
+++ b/.changeset/little-spiders-develop.md
@@ -1,0 +1,5 @@
+---
+'@codeshift/cli': minor
+---
+
+Allows to use the sequence flag in a monorepo development context

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -73,9 +73,19 @@ export default async function main(paths: string[], flags: Flags) {
         selectedConfig.config.transforms &&
         selectedConfig.config.transforms[answers.codemod.selection]
       ) {
-        transforms.push(
-          selectedConfig.config.transforms[answers.codemod.selection],
-        );
+        if (flags.sequence) {
+          Object.entries(
+            selectedConfig.config.transforms as Record<string, string>,
+          )
+            .filter(([key]) =>
+              semver.satisfies(key, `>=${answers.codemod.selection}`),
+            )
+            .forEach(([, path]) => transforms.push(path));
+        } else {
+          transforms.push(
+            selectedConfig.config.transforms[answers.codemod.selection],
+          );
+        }
       } else if (
         selectedConfig.config.presets &&
         selectedConfig.config.presets[answers.codemod.selection]

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -125,7 +125,9 @@ export default async function main(paths: string[], flags: Flags) {
       const answers = await inquirer.prompt([getConfigPrompt(config)]);
 
       if (config.transforms && config.transforms[answers.codemod]) {
-        transforms.push(config.transforms[answers.codemod]);
+        Object.entries(config.transforms)
+          .filter(([key]) => semver.satisfies(key, `>=${answers.codemod}`))
+          .forEach(([, path]) => transforms.push(path));
       } else if (config.presets && config.presets[answers.codemod]) {
         transforms.push(config.presets[answers.codemod]);
       }


### PR DESCRIPTION
### What?
This allows to use the `--sequence` flag when working in a local monorepo context.