### PR TITLE
Adds remove-unused-vars to javascript codeshift package

### DIFF
--- a/community/javascript/codeshift.config.js
+++ b/community/javascript/codeshift.config.js
@@ -3,10 +3,12 @@ module.exports = {
   targets: [],
   description: 'Codemods for javascript',
   transforms: {},
+
   presets: {
     'remove-console-log': require.resolve('./remove-console-log/transform'),
     'remove-debugger': require.resolve('./remove-debugger/transform'),
     'sort-object-props': require.resolve('./sort-object-props/transform'),
     'var-to-let': require.resolve('./var-to-let/transform'),
+    'no-unused-vars': require.resolve('./no-unused-vars/transform'),
   },
 };

--- a/community/javascript/no-unused-vars/README.md
+++ b/community/javascript/no-unused-vars/README.md
@@ -1,0 +1,14 @@
+# javascript#no-unused-vars
+
+Detects and removes unused variables in JavaScript code.
+
+```js
+/* INPUT */
+const x = 1;
+const y = 2;
+console.log(y);
+
+/* OUTPUT */
+const y = 2;
+console.log(y);
+```

--- a/community/javascript/no-unused-vars/transform.spec.ts
+++ b/community/javascript/no-unused-vars/transform.spec.ts
@@ -1,0 +1,179 @@
+import { applyTransform } from '@codeshift/test-utils';
+import * as transformer from './transform';
+
+describe('javascript#no-unused-vars transform', () => {
+  it('should remove unused variables', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+const x = 1;
+const y = 2;
+console.log(y);
+    `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "const y = 2;
+      console.log(y);"
+    `);
+  });
+
+  it('should not remove used variables', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+const x = 1;
+const y = 2;
+console.log(x + y);
+    `,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "const x = 1;
+      const y = 2;
+      console.log(x + y);"
+    `);
+  });
+
+  it('should remove unused variables with complex declarations', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+let [, y] = [1, 2];
+console.log(y);
+    `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`"console.log(y);"`);
+  });
+
+  it('should remove unused variables with complex declarations', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+let [, y] = [1, 2];
+console.log(y);
+    `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`"console.log(y);"`);
+  });
+
+  it.only('should remove unused function parameters', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+function foo(a, b) {
+  console.log(a);
+}
+foo(1);
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "function foo(a) {
+        console.log(a);
+      }
+      foo(1);"
+    `);
+  });
+
+  it('should remove unused variable in nested scope', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+function foo() {
+  if (true) {
+    const a = 1;
+  }
+}
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "function foo() {
+        if (true) {}
+      }"
+    `);
+  });
+
+  it('should remove unused variable in for loop', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+for (let i = 0; i < 10; i++) {
+  const a = i;
+}
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`"for (let i = 0; i < 10; i++) {}"`);
+  });
+
+  it('should remove unused variable in destructuring assignment', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+const { a, b } = { a: 1, b: 2 };
+console.log(a);
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "const { a } = { a: 1, b: 2 };
+      console.log(a);"
+    `);
+  });
+
+  it('should remove unused function argument', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+function foo(a, b) {
+  console.log(a);
+}
+foo(1);
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "function foo(a) {
+        console.log(a);
+      }
+      foo(1);"
+    `);
+  });
+
+  it('should not remove used variable in conditional', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+let a;
+if (true) {
+  a = 1;
+}
+console.log(a);
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "let a;
+      if (true) {
+        a = 1;
+      }
+      console.log(a);"
+    `);
+  });
+
+  it('should remove unused function declaration', async () => {
+    const result = await applyTransform(
+      transformer,
+      `
+function foo() {
+  console.log('Hello, world!');
+}
+      `,
+    );
+
+    expect(result).toMatchInlineSnapshot(`""`);
+  });
+});

--- a/community/javascript/no-unused-vars/transform.ts
+++ b/community/javascript/no-unused-vars/transform.ts
@@ -1,0 +1,37 @@
+import { API, FileInfo, Options } from 'jscodeshift';
+
+export default function transformer(
+  file: FileInfo,
+  { jscodeshift: j }: API,
+  options: Options,
+) {
+  const source = j(file.source);
+
+  // Find all variable declarations in the code
+  const declarations = source.find(j.VariableDeclaration).filter(path => {
+    // Check if the variable is unused
+    // @ts-expect-error
+    const varName = path.node.declarations[0].id.name;
+
+    const isUsed =
+      j(path.scope.path)
+        .find(j.Identifier, { name: varName })
+        // Exclude identifiers that are part of a variable declaration
+        .filter(
+          identifierPath =>
+            identifierPath.parent.node.type !== 'VariableDeclarator',
+        )
+        .size() > 0;
+
+    return !isUsed;
+  });
+
+  if (!declarations.length) {
+    return file.source;
+  }
+
+  // Remove unused variable declarations from the code
+  declarations.remove();
+
+  return source.toSource(options.printOptions);
+}


### PR DESCRIPTION
Detects and removes unused variables in JavaScript code.

**Input**

```js
/* INPUT */
const x = 1;
const y = 2;
console.log(y);
```

**Output**
```js
/* OUTPUT */
const y = 2;
console.log(y);
```